### PR TITLE
Fix initial group selection count

### DIFF
--- a/maker.py
+++ b/maker.py
@@ -914,6 +914,19 @@ class CourseSimulatorGenerator:
 
                 // 지정과목 자동 선택
                 selectedCourses[semester] = [...requiredCourses];
+                // 선택 제한 그룹에 지정과목 반영
+                requiredCourses.forEach(course => {{
+                    if (course.selection_group && course.selection_limit) {{
+                        const key = `${{semester}}_${{course.group}}_${{course.selection_group}}`;
+                        if (selectionGroups[key] && !selectionGroups[key].selected.find(c => c.name === course.name)) {{
+                            selectionGroups[key].selected.push(course);
+                        }}
+                    }}
+                }});
+            }});
+            Object.keys(selectionGroups).forEach(key => {{
+                const info = selectionGroups[key];
+                updateSelectionLimit(info.semester, info.group, info.name);
             }});
         }}
 


### PR DESCRIPTION
## Summary
- count required courses towards group selection limits
- refresh selection counts after initializing groups

## Testing
- `python -m py_compile maker.py`
- `python - <<'PY'
import pandas as pd
import tempfile, os

data = {
    '학기': ['1학기', '1학기', '1학기', '1학기'],
    '유형': ['공통', '공통', '공통', '공통'],
    '과목명': ['국어', '영어', '수학', '과학'],
    '학점': [2,2,2,2],
    '지정여부': ['지정','선택','선택','선택'],
    '교과(군)': ['필수','선택','선택','선택'],
    '그룹 내 선택수': [None,'선택A 택2', '선택A 택2', '선택A 택2'],
}

with tempfile.NamedTemporaryFile(suffix='.xlsx', delete=False) as tmp:
    pd.DataFrame(data).to_excel(tmp.name, index=False)
    tmp_path = tmp.name
from maker import CourseSimulatorGenerator

g = CourseSimulatorGenerator()
print('load', g.load_excel_data(tmp_path))
print('process', g.process_data())
html_path = g.generate_html('/tmp/out.html')
print('out', html_path)
print('exist', html_path and os.path.exists(html_path))
PY`

------
https://chatgpt.com/codex/tasks/task_b_683f580dc1e8832d914ce9959c163df7