### PR TITLE
Fix braces in HTML template

### DIFF
--- a/maker.py
+++ b/maker.py
@@ -972,13 +972,13 @@ class CourseSimulatorGenerator:
                 
                 // 선택 그룹별로 분리
                 const selectionGroupMap = {{}};
-                groupCourses.forEach(course => {
-                    const groupKey = course.selection_group ? `${semester}-${course.selection_group}` : 'default';
-                    if (!selectionGroupMap[groupKey]) {
+                groupCourses.forEach(course => {{
+                    const groupKey = course.selection_group ? `${{semester}}-${{course.selection_group}}` : 'default';
+                    if (!selectionGroupMap[groupKey]) {{
                         selectionGroupMap[groupKey] = [];
-                    }
+                    }}
                     selectionGroupMap[groupKey].push(course);
-                });
+                }});
 
                 Object.keys(selectionGroupMap).forEach(selectionGroupKey => {{
                     const courses = selectionGroupMap[selectionGroupKey];


### PR DESCRIPTION
## Summary
- escape curly braces inside JS template strings used for groupKey generation
- update if statement braces in HTML template

## Testing
- `python -m py_compile maker.py`

------
https://chatgpt.com/codex/tasks/task_b_683f620258e8832da1422c0329078de3