### PR TITLE
Fix KeyError in HTML template comment

### DIFF
--- a/maker.py
+++ b/maker.py
@@ -792,7 +792,7 @@ class CourseSimulatorGenerator:
         
         let selectedCourses = {{}};
         let semesterList = [];
-        let selectionGroups = {{}}; // Key: "학기_선택그룹명", Value: { semester, name, limit, selected: [] }
+        let selectionGroups = {{}}; // Key: "학기_선택그룹명", Value: {{ semester, name, limit, selected: [] }}
         const groupTabName = '교과군별';
         let allTabs = [];
 


### PR DESCRIPTION
## Summary
- escape braces in JS comment to prevent `KeyError` during HTML generation

## Testing
- `python -m py_compile maker.py`


------
https://chatgpt.com/codex/tasks/task_b_683f8cf68cb0832daf97038c0c036ab0